### PR TITLE
New guild experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Changelog v1.7 - Beryllium
+
+## Added
+
+ - Algalon can now be added to any server by clicking the 'Add to Server' button on his profile on Discord! Use at your own risk. ;)
+ - As such, I've added a new welcome message when Algalon first joins a server. This message will be sent to the system channel if possible, otherwise it'll fall back to the 'community updates' channel. Both of these channels are set by server admins in the server settings, and if neither are available he just remains silent.
+ - Algalon will now publish messages to a channel in the Official™️ GhostBots Discord server, so if you don't want to add Algalon to your server, let me know and I'll invite to the GhostBots server where you can follow the announcement channel, and have all the messages propagated to your server! (you lose the ability to customize branches you wanna watch though)
+ - Some minor debugging/administration commands.
+
+## Fixed
+
+ - Servers subscribed to Diablo 4 updates but that haven't set their Diablo 4 channel will now automatically have the Diablo 4 channel set to whatever their Warcraft channel is.
+ - Minor optimizations in the guild configuration area.
+
+
+
 # Changelog v1.6 - Diamond
 
 ## Added

--- a/bot.py
+++ b/bot.py
@@ -113,7 +113,7 @@ class CDNBotHelpCommand(commands.HelpCommand):
 class CDNBot(bridge.Bot):
     """This is the almighty CDN bot, also known as Algalon. Inherits from `discord.ext.bridge.Bot`."""
 
-    COGS_LIST = ["watcher"]
+    COGS_LIST = ["admin", "watcher", "nux"]
 
     def __init__(self, command_prefix, help_command=None, **options):
         command_prefix = command_prefix or "!"
@@ -179,6 +179,6 @@ if __name__ == "__main__":
         status=discord.Status.online,
         activity=activity,
         auto_sync_commands=True,
-        debug_guilds=debug_guilds,  # debug_guilds,
+        debug_guilds=debug_guilds,
     )
     bot.run(token)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -63,6 +63,14 @@ Banner: {guild.banner.url if guild.banner else 'N/A'}
             message, ephemeral=True, delete_after=300
         )
 
+    @commands.is_owner()
+    @bridge.bridge_command(name="forceupdate", guild_ids=DEBUG_GUILDS, guild_only=True)
+    async def force_update_check(self, ctx: bridge.BridgeApplicationContext):
+        """Forces a CDN check."""
+        watcher = self.bot.get_cog("CDNCog")
+        await watcher.cdn_auto_refresh()
+        await ctx.respond("Update in progress...")
+
 
 def setup(bot):
     bot.add_cog(AdminCog(bot))

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -5,7 +5,7 @@ from discord.ext import bridge, commands
 
 logger = logging.getLogger("discord.admin")
 
-DEBUG_GUILDS = [int(os.getenv("DEBUG_GUILD_ID"))]
+DEBUG_GUILDS = [318246001309646849]
 
 
 class AdminCog(commands.Cog):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,0 +1,68 @@
+import os
+import discord
+import logging
+
+from discord.ext import bridge, commands
+
+logger = logging.getLogger("discord.admin")
+
+DEBUG_GUILDS = [int(os.getenv("DEBUG_GUILD_ID")), int(os.getenv("DEBUG_GUILD_ID2"))]
+
+
+class AdminCog(commands.Cog):
+    def __init__(self, bot: bridge.Bot):
+        self.bot = bot
+
+    @commands.is_owner()
+    @bridge.bridge_command(name="reload", guild_ids=DEBUG_GUILDS)
+    async def reload_cog(self, ctx: bridge.BridgeApplicationContext, cog_name: str):
+        """Reloads a currently loaded cog."""
+
+        if cog_name == self.qualified_name:
+            await ctx.interaction.response.send_message(
+                "You cannot kill a god.", ephemeral=True, delete_after=300
+            )
+            return
+
+        cog_name_internal = f"cogs.{cog_name}"
+        logger.debug(f"Reloading {cog_name_internal}")
+        try:
+            self.bot.reload_extension(cog_name_internal)
+        except Exception as exc:
+            logger.error(f"Error reloading {cog_name_internal}.")
+            await self.bot.notify_owner_of_command_exception(ctx, exc)
+            await ctx.interaction.response.send_message(
+                f"busted.\n`{exc}`", ephemeral=True, delete_after=300
+            )
+            return
+
+        logger.debug(f"{cog_name_internal} reloaded successfully.")
+
+        await ctx.interaction.response.send_message(
+            f"`{cog_name}` reloaded successfully."
+        )
+
+    @commands.is_owner()
+    @bridge.bridge_command(name="guilds", guild_ids=DEBUG_GUILDS, guild_only=True)
+    async def get_all_guilds(self, ctx: bridge.BridgeApplicationContext):
+        """Dumps details for all guilds Algalon is a part of."""
+        message = "```\n"
+        for guild in self.bot.guilds:
+            guild = await self.bot.fetch_guild(guild.id)
+            message += f"""
+{guild.name}
+ID: {guild.id}
+Members (approx): {guild.approximate_member_count}
+Description: {guild.description or 'N/A'}
+Icon: {guild.icon.url if guild.icon else 'N/A'}
+Banner: {guild.banner.url if guild.banner else 'N/A'}
+"""
+
+        message += "```"
+        await ctx.interaction.response.send_message(
+            message, ephemeral=True, delete_after=300
+        )
+
+
+def setup(bot):
+    bot.add_cog(AdminCog(bot))

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -5,7 +5,7 @@ from discord.ext import bridge, commands
 
 logger = logging.getLogger("discord.admin")
 
-DEBUG_GUILDS = [int(os.getenv("DEBUG_GUILD_ID")), int(os.getenv("DEBUG_GUILD_ID2"))]
+DEBUG_GUILDS = [int(os.getenv("DEBUG_GUILD_ID"))]
 
 
 class AdminCog(commands.Cog):

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,5 +1,4 @@
 import os
-import discord
 import logging
 
 from discord.ext import bridge, commands

--- a/cogs/cdn_cache.py
+++ b/cogs/cdn_cache.py
@@ -85,6 +85,12 @@ class CDNCache:
             ):
                 newBuild["encrypted"] = True
 
+            # ignore builds with lower seqn numbers because it's probably just a caching issue
+            if (newBuild["seqn"] > 0) and newBuild["seqn"] < file_json[
+                self.CONFIG.indices.BUILDINFO
+            ][branch]["seqn"]:
+                return False
+
             for area in self.CONFIG.AREAS_TO_CHECK_FOR_UPDATES:
                 if branch in file_json[self.CONFIG.indices.BUILDINFO]:
                     if (
@@ -206,6 +212,7 @@ class CDNCache:
             data = response.split("\n")
             if len(data) < 3:
                 return False
+            seqn = data[1].replace("## seqn = ", "")
             data = data[2].split("|")
             region = data[0]
             build_config = data[1]
@@ -222,6 +229,7 @@ class CDNCache:
                 "build_text": build_text,
                 "product_config": product_config,
                 "encrypted": await self.TACT.is_encrypted(branch, product_config),
+                "seqn": int(seqn),
             }
 
             return output

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -180,6 +180,7 @@ class CacheConfig:
         "build_text": "no-data",
         "product_config": "no-data",
         "encrypted": None,
+        "seqn": 0,
     }
 
     settings = Settings()

--- a/cogs/guild_config.py
+++ b/cogs/guild_config.py
@@ -109,6 +109,19 @@ class GuildCFG:
         else:
             return guild_config[_setting["name"]]
 
+    def validate_guild_configs(self):
+        logger.debug(f"Validating guild configurations...")
+        all_configs = self.get_all_guild_configs()
+
+        for guild_id, config in all_configs.items():
+            for key in self.CONFIG.settings.KEYS:
+                _setting: dict = getattr(self.CONFIG.settings, key.upper())
+                if key not in config:
+                    self.reset_guild_setting_to_default(guild_id, _setting)
+                elif key == "d4_channel" and config[key] == 0:
+                    channel = config["channel"]
+                    self.update_guild_config(guild_id, "d4_channel", channel)
+
     def reset_guild_setting_to_default(self, guild_id: int | str, setting: dict):
         logger.debug(f"Resetting {setting} to default for guild {guild_id}.")
         logger.debug(f"Default value: {setting['default']}, name: {setting['name']}")

--- a/cogs/guild_config.py
+++ b/cogs/guild_config.py
@@ -120,7 +120,7 @@ class GuildCFG:
                     self.reset_guild_setting_to_default(guild_id, _setting)
                 elif key == "d4_channel" and config[key] == 0:
                     channel = config["channel"]
-                    self.update_guild_config(guild_id, "d4_channel", channel)
+                    self.update_guild_config(guild_id, channel, "d4_channel")
 
     def reset_guild_setting_to_default(self, guild_id: int | str, setting: dict):
         logger.debug(f"Resetting {setting} to default for guild {guild_id}.")

--- a/cogs/guild_config.py
+++ b/cogs/guild_config.py
@@ -136,7 +136,7 @@ class GuildCFG:
 
         self.update_guild_config(guild_id, old_channel_id, "d4_channel")
 
-        return self.get_guild_setting(guild_id, setting["name"])
+        return True
 
     def update_guild_config(self, guild_id: int | str, new_data, setting):
         logger.debug(f"Updating guild configuration for guild {guild_id}...")

--- a/cogs/guild_config.py
+++ b/cogs/guild_config.py
@@ -26,7 +26,7 @@ class GuildCFG:
             self.init_guild_cfg()
 
         # remember to clear and update with new builds - contains an old key and a new value
-        self.KEYS_TO_PATCH = ["channel", "d4_channel"]
+        self.KEYS_TO_PATCH = ["d4_channel"]
 
     # GUILD CFG DEFAULTS
 
@@ -102,10 +102,10 @@ class GuildCFG:
         _setting: dict = getattr(self.CONFIG.settings, setting.upper())
 
         if not _setting["name"] in guild_config:
-            if _setting["name"] in self.KEYS_TO_PATCH:
+            return self.reset_guild_setting_to_default(guild_id, _setting)
+        elif _setting["name"] in self.KEYS_TO_PATCH:
+            if _setting["name"] == "d4_channel" and guild_config["d4_channel"] == 0:
                 return self.patch_guild_setting(guild_id, _setting)
-            else:
-                return self.reset_guild_setting_to_default(guild_id, _setting)
         else:
             return guild_config[_setting["name"]]
 

--- a/cogs/nux.py
+++ b/cogs/nux.py
@@ -1,0 +1,60 @@
+import discord
+import logging
+
+from discord.ext import bridge, commands, pages, tasks
+
+from .guild_config import GuildCFG
+
+logger = logging.getLogger("discord.nux")
+
+
+class GuildNUX(commands.Cog):
+    def __init__(self, bot: bridge.Bot):
+        self.bot = bot
+        self.guild_cfg = GuildCFG()
+        self.watcher = self.bot.get_cog("CDNCog")
+
+    @commands.Cog.listener("on_guild_join")
+    async def on_guild_join(self, guild: discord.Guild):
+        logger.info(f"Joined new guild {guild.id}!")
+
+        if not self.guild_cfg.does_guild_config_exist(guild.id):
+            self.guild_cfg.add_guild_config(guild.id)
+
+        channel = guild.system_channel or guild.public_updates_channel
+        if not channel:
+            return
+
+        cmd_link_set_channel = self.watcher.get_command_link("cdnsetchannel")
+        cmd_link_get_watchlist = self.watcher.get_command_link("cdnwatchlist")
+        cmd_link_add_to_watchlist = self.watcher.get_command_link("cdnaddtowatchlist")
+        cmd_link_rm_from_watchlist = self.watcher.get_command_link(
+            "cdnremovefromwatchlist"
+        )
+        cmd_link_data = self.watcher.get_command_link("cdndata")
+
+        owner_user = await self.bot.get_or_fetch_user(self.bot.owner_id)
+        owner_mention = owner_user.mention
+
+        bot_display_name = self.bot.user.display_name
+
+        nux_message = f"""
+# Greetings from the Titans!
+I'm {bot_display_name} and I'll be {guild.name}'s *personal* constellar :crystal_ball:.
+
+**Here's a few tips to help you get started:**
+- Select the channels you want me to send notifications to by calling {cmd_link_set_channel} **from** the channel you want to use. You can set a different channel for each supported game.
+- Check out your server's watchlist with {cmd_link_get_watchlist}
+- Add branches to your server's watchlist with {cmd_link_add_to_watchlist} and remove them with {cmd_link_rm_from_watchlist}
+- View the currently cached data with {cmd_link_data}
+
+:blue_heart: Thanks for trying out Algalon! :blue_heart:
+
+If you have any questions, concerns, or suggestions, please reach out to {owner_mention} here on Discord, or open a GitHub issue [here](https://github.com/Ghostopheles/better-algalon).
+"""
+
+        await channel.send(nux_message)
+
+
+def setup(bot):
+    bot.add_cog(GuildNUX(bot))

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -55,7 +55,7 @@ class CDNCog(commands.Cog):
                 )
                 self.guild_cfg.add_guild_config(guild.id)
 
-        for guild_id in self.guild_cfg.get_all_guild_configs():
+        for guild_id in self.guild_cfg.get_all_guild_configs().keys():
             for key in self.guild_cfg.CONFIG.settings.KEYS:
                 self.guild_cfg.get_guild_setting(guild_id, key)
 
@@ -388,11 +388,6 @@ class CDNCog(commands.Cog):
         await ctx.interaction.response.send_message(
             error_message, ephemeral=True, delete_after=300
         )
-
-    @commands.Cog.listener("on_guild_join")
-    async def on_guild_join(self, guild: discord.Guild):
-        logger.info(f"Joined new guild {guild.id}!")
-        self.guild_cfg.add_guild_config(guild.id)
 
     # DISCORD COMMANDS
 

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -1,5 +1,6 @@
 """This is the module that handles watching the Blizzard CDN and posting updates to the correct places."""
 
+import os
 import time
 import httpx
 import secrets
@@ -241,7 +242,12 @@ class CDNCog(commands.Cog):
 
                     if actual_embed and channel:
                         logger.info("Sending CDN update post and tweet...")
-                        await channel.send(embed=actual_embed)  # type: ignore
+                        msg_nonce = secrets.token_urlsafe()
+                        message = await channel.send(embed=actual_embed, nonce=msg_nonce)  # type: ignore
+
+                        if channel.id == int(os.getenv("ANNOUNCEMENT_CHANNEL")):
+                            await message.publish()
+
                         response = await self.twitter.send_tweet(
                             actual_embed.to_dict(), token
                         )

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -245,15 +245,14 @@ class CDNCog(commands.Cog):
 
                         if channel.id == int(os.getenv("ANNOUNCEMENT_CHANNEL")):
                             await message.publish()
-
-                        response = await self.twitter.send_tweet(
-                            actual_embed.to_dict(), token
-                        )
-                        if response:
-                            logger.error(
-                                f"Tweet failed with: {response}.\n{actual_embed.to_dict()}"
+                            response = await self.twitter.send_tweet(
+                                actual_embed.to_dict(), token
                             )
-                            await self.notify_owner_of_exception(response)
+                            if response:
+                                logger.error(
+                                    f"Tweet failed with: {response}.\n{actual_embed.to_dict()}"
+                                )
+                                await self.notify_owner_of_exception(response)
                     elif actual_embed and not channel:
                         logger.error(f"No channel found for guild {guild}, aborting.")
                         continue

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -56,10 +56,9 @@ class CDNCog(commands.Cog):
                 )
                 self.guild_cfg.add_guild_config(guild.id)
 
-        for guild_id in self.guild_cfg.get_all_guild_configs().keys():
-            for key in self.guild_cfg.CONFIG.settings.KEYS:
-                self.guild_cfg.get_guild_setting(guild_id, key)
+        self.guild_cfg.validate_guild_configs()
 
+        for guild_id in self.guild_cfg.get_all_guild_configs().keys():
             if int(guild_id) not in [guild.id for guild in self.bot.guilds]:
                 logger.info(
                     f"No longer a part of guild {guild_id}, removing guild configuration..."

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -118,7 +118,6 @@ class CDNCog(commands.Cog):
                 logger.warning(
                     f"Guild {guild_id} has not chosen a notification channel, skipping..."
                 )
-                raise Exception(f"Notification channel not found for {game}.")
 
             color = (
                 discord.Color.dark_blue() if game == "wow" else discord.Color.dark_red()

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -241,7 +241,7 @@ class CDNCog(commands.Cog):
 
                     if actual_embed and channel:
                         logger.info("Sending CDN update post and tweet...")
-                        msg_nonce = secrets.token_urlsafe()
+                        msg_nonce = secrets.token_urlsafe(24)
                         message = await channel.send(embed=actual_embed, nonce=msg_nonce)  # type: ignore
 
                         if channel.id == int(os.getenv("ANNOUNCEMENT_CHANNEL")):

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -118,6 +118,7 @@ class CDNCog(commands.Cog):
                 logger.warning(
                     f"Guild {guild_id} has not chosen a notification channel, skipping..."
                 )
+                continue
 
             color = (
                 discord.Color.dark_blue() if game == "wow" else discord.Color.dark_red()

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -241,8 +241,7 @@ class CDNCog(commands.Cog):
 
                     if actual_embed and channel:
                         logger.info("Sending CDN update post and tweet...")
-                        msg_nonce = secrets.token_urlsafe(24)
-                        message = await channel.send(embed=actual_embed, nonce=msg_nonce)  # type: ignore
+                        message = await channel.send(embed=actual_embed)  # type: ignore
 
                         if channel.id == int(os.getenv("ANNOUNCEMENT_CHANNEL")):
                             await message.publish()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 py-cord
+py-cord[speed]
 httpx
 tweepy[async]


### PR DESCRIPTION
I recently enabled the ability for anyone to add Algalon to their server using a button on his profile. With this new guild experience, he'll greet the server's he joins with a quick rundown on what to do to configure the bot.

First, he'll check if the designated 'system channel' is available and he can send messages to it - if not he'll fall back to the 'community updates' channel where the server staff (are intended to) receive Discord updates n' such.

Looking forward to seeing Algalon grow some more, and I hope this doesn't cause any catastrophic issues :)))