### PR TITLE
Handle errors when fetching channel

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,5 +79,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm/v7
           secrets: DEBUG=False

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,9 +48,9 @@ jobs:
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+        uses: sigstore/cosign-installer@v3.1.2
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v3.1.2'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,13 +45,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3.1.2
-        with:
-          cosign-release: 'v3.1.2'
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -88,17 +81,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           secrets: DEBUG=False
-
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM --platform=$TARGETPLATFORM python:latest
+FROM --platform=$TARGETPLATFORM python:3.11.6
 
 WORKDIR /usr/algalon
 

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -251,7 +251,13 @@ class CDNCog(commands.Cog):
 
                     if actual_embed and channel:
                         logger.info("Sending CDN update post and tweet...")
-                        message = await channel.send(embed=actual_embed)  # type: ignore
+                        try:
+                            message = await channel.send(embed=actual_embed)  # type: ignore
+                        except discord.Forbidden:
+                            logger.error(
+                                f"No permission to post to chosen channel for guild {guild}"
+                            )
+                            continue
 
                         if channel.id == int(os.getenv("ANNOUNCEMENT_CHANNEL")):
                             await message.publish()

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -236,7 +236,17 @@ class CDNCog(commands.Cog):
                     continue
 
                 for embed in embeds:
-                    channel = await guild.fetch_channel(embed["target"])
+                    try:
+                        channel = await guild.fetch_channel(embed["target"])
+                    except discord.NotFound:
+                        logger.error(f"Chosen channel not found for guild {guild}")
+                        continue
+                    except discord.Forbidden:
+                        logger.error(
+                            f"No permission to access chosen channel for guild {guild}"
+                        )
+                        continue
+
                     actual_embed = embed["embed"]  # god save me
 
                     if actual_embed and channel:

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -253,6 +253,9 @@ class CDNCog(commands.Cog):
                         logger.info("Sending CDN update post and tweet...")
                         try:
                             message = await channel.send(embed=actual_embed)  # type: ignore
+                        except discord.NotFound:
+                            logger.error(f"Chosen channel not found for guild {guild}")
+                            continue
                         except discord.Forbidden:
                             logger.error(
                                 f"No permission to post to chosen channel for guild {guild}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.8.2
 py-cord
 py-cord[speed]
 httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools
 py-cord
 httpx
 tweepy[async]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-aiohttp==3.8.2
 py-cord
-py-cord[speed]
 httpx
 tweepy[async]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 py-cord
 httpx
 tweepy[async]


### PR DESCRIPTION
If a server deletes their notification channel but doesn't update it in the bot config, it'll throw an error and prevent updates from being pushed out to the wider world.