### PR TITLE
Remove hardcoded `catalogs` region

### DIFF
--- a/cogs/cdn_cache.py
+++ b/cogs/cdn_cache.py
@@ -182,7 +182,18 @@ class CDNCache:
             logger.warning(f"No response for {branch}")
             return
 
-        region = "PUB-29" if branch == "catalogs" else "us"
+        if branch == "catalogs":
+            highest_region = None
+            highest_build = 0
+            for region, data in _data.items():
+                build_text = int(data.build_text)
+                if build_text > highest_build:
+                    highest_build = build_text
+                    highest_region = region
+
+            region = highest_region
+        else:
+            region = "us"
 
         _data = _data[region]
         data = _data.__dict__()

--- a/cogs/ribbit_async.py
+++ b/cogs/ribbit_async.py
@@ -156,7 +156,7 @@ class RibbitClient:
         output = {}
 
         for region in data:
-            if region != "us" and region != "PUB-29":
+            if region != "us" and product != "catalogs":
                 continue
 
             d = data[region]
@@ -164,7 +164,7 @@ class RibbitClient:
             regionData["region"] = region
             regionData["branch"] = product
 
-            if region != "PUB-29":
+            if product != "catalogs":
                 try:
                     encrypted = await TACT.is_encrypted(
                         product, regionData["ProductConfig"]


### PR DESCRIPTION
For Battlenet catalogs, the 'region' is a bit arcane - instead of hardcoding it to a specific region, we're just gonna grab the region with the highest version number, since I think that's the correct way to do it.