### PR TITLE
Add DM notifications and migrate commands into command groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Changelog v1.9.2 - Gallium
+
+## Added
+- DM notifications have been enabled frfr on all server Algalon is a part of.
+
+## Changed
+- Commands have been restructured.
+   - Watchlist commands have been moved to `/watchlist {add|remove|view}`
+   - Channel commands have been moved to `/channel {set|get}`
+   - DM commands have been moved to `/dm {subscribe|unsubscribe|view}`
+
 # Changelog v1.9 - Yttrium
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # better-algalon
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![LastUpdate](https://img.shields.io/github/last-commit/Ghostamoose/better-algalon?style=flat-square) [![Docker](https://github.com/Ghostamoose/better-algalon/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/Ghostamoose/better-algalon/actions/workflows/docker-publish.yml)
 
-v1.9 - Yttrium
+v1.9.2 - Gallium
 
 A bot that watches Blizzard's CDN and automatically posts new build updates to specified Discord channels.
 
@@ -82,23 +82,23 @@ Algalon provides a number of commands to control your guild's (server) watchlist
 
 #### Watchlist Controls
 
-`/addtowatchlist`*: Adds a specific branch to your guild's watchlist. Specify multiple branches at once by separating them with a comma.
+`/watchlist add`*: Adds a specific branch to your guild's watchlist. Specify multiple branches at once by separating them with a comma.
 
-`/removefromwatchlist`*: Removes a specific branch to your guild's watchlist.
+`/watchlist remove`*: Removes a specific branch to your guild's watchlist.
 
-`/watchlist`: Returns your guild's current watchlist.
+`/watchlist view`: Returns your guild's current watchlist.
 
 #### Notification Channel Controls
 
-`/setchannel`*: Sets the channel in which it's invoked as the notification channel for your guild. Optionally, specify a game to set the notification channel for that game. Defaults to Warcraft.
+`/channel set`*: Sets the channel in which it's invoked as the notification channel for your guild. Optionally, specify a game to set the notification channel for that game. Defaults to Warcraft.
 
-`/getchannel`: Returns the current notification channel for your guild. Optionally, specify a game to get the notification channel for that game. Defaults to Warcraft.
+`/channel get`: Returns the current notification channel for your guild. Optionally, specify a game to get the notification channel for that game. Defaults to Warcraft.
 
 #### User DM Updates
 
-`/subscribe`: Subscribes the user to DM updates for the given branches. Supports comma-delimited input.
+`/dm subscribe`: Subscribes the user to DM updates for the given branches. Supports comma-delimited input.
 
-`/unsubscribe`: Unsubscribes the user from DM updates for the given branches. Supports comma-delimited input.
+`/dm unsubscribe`: Unsubscribes the user from DM updates for the given branches. Supports comma-delimited input.
 
-`/subscribed`: Returns all the branches you're currently subscribed to.
+`/dm view`: Returns all the branches you're currently subscribed to.
 

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -2,7 +2,6 @@ import io
 import logging
 import discord
 
-from time import time
 from discord.ext import bridge, commands
 
 logger = logging.getLogger("discord.admin")
@@ -14,15 +13,22 @@ DEBUG_GUILDS = [
     1144396478840844439,
 ]
 
-HOME_GUILD = 318246001309646849
+HOME_GUILD = [318246001309646849]
 
 
 class AdminCog(commands.Cog):
     def __init__(self, bot: bridge.Bot):
         self.bot = bot
 
+    admin_commands = discord.SlashCommandGroup(
+        name="admin",
+        description="Administration commands",
+        guild_only=True,
+        guild_ids=HOME_GUILD,
+    )
+
     @commands.is_owner()
-    @bridge.bridge_command(name="reload", guild_ids=[HOME_GUILD], guild_only=True)
+    @admin_commands.command(name="reload")
     async def reload_cog(self, ctx: bridge.BridgeApplicationContext, cog_name: str):
         """Reloads a currently loaded cog."""
 
@@ -51,7 +57,7 @@ class AdminCog(commands.Cog):
         )
 
     @commands.is_owner()
-    @bridge.bridge_command(name="guilds", guild_ids=[HOME_GUILD], guild_only=True)
+    @admin_commands.command(name="guilds")
     async def get_all_guilds(self, ctx: bridge.BridgeApplicationContext):
         """Dumps details for all guilds Algalon is a part of."""
         await ctx.defer()
@@ -69,13 +75,24 @@ Members (approx): {guild.approximate_member_count}\n
         message_bytes.close()
 
     @commands.is_owner()
-    @bridge.bridge_command(name="forceupdate", guild_ids=[HOME_GUILD], guild_only=True)
+    @admin_commands.command(name="forceupdate")
     async def force_update_check(self, ctx: bridge.BridgeApplicationContext):
         """Forces a CDN check."""
         watcher = self.bot.get_cog("CDNCog")
         await ctx.defer()
         await watcher.cdn_auto_refresh()
         await ctx.respond("Updates complete.", ephemeral=True, delete_after=300)
+
+    @commands.is_owner()
+    @admin_commands.command(name="nuxtest")
+    async def nuxtest(self, ctx: bridge.BridgeApplicationContext):
+        guild = ctx.guild
+        nux_cog = self.bot.get_cog("GuildNUX")
+        message = await nux_cog.get_nux_message(guild)
+
+        await ctx.respond(message, ephemeral=True, delete_after=300)
+
+    # funni commands
 
     @bridge.bridge_command(
         name="alien",
@@ -101,15 +118,6 @@ Members (approx): {guild.approximate_member_count}\n
 
         await message.add_reaction(emoji)
         await ctx.respond("gottem", ephemeral=True, delete_after=5)
-
-    @commands.is_owner()
-    @bridge.bridge_command(name="nuxtest", guild_ids=[HOME_GUILD], guild_only=True)
-    async def nuxtest(self, ctx: bridge.BridgeApplicationContext):
-        guild = ctx.guild
-        nux_cog = self.bot.get_cog("GuildNUX")
-        message = nux_cog.get_nux_message(guild)
-
-        await ctx.respond(message, ephemeral=True, delete_after=300)
 
 
 def setup(bot):

--- a/cogs/nux.py
+++ b/cogs/nux.py
@@ -18,11 +18,17 @@ class GuildNUX(commands.Cog):
         self,
         guild: discord.Guild,
     ) -> str:
-        cmd_link_set_channel = self.watcher.get_command_link("setchannel")
-        cmd_link_get_watchlist = self.watcher.get_command_link("watchlist")
-        cmd_link_add_to_watchlist = self.watcher.get_command_link("addtowatchlist")
+        cmd_link_set_channel = self.watcher.get_command_link(
+            "channel set", self.watcher.channel_commands
+        )
+        cmd_link_get_watchlist = self.watcher.get_command_link(
+            "watchlist view", self.watcher.watchlist_commands
+        )
+        cmd_link_add_to_watchlist = self.watcher.get_command_link(
+            "watchlist add", self.watcher.watchlist_commands
+        )
         cmd_link_rm_from_watchlist = self.watcher.get_command_link(
-            "removefromwatchlist"
+            "watchlist remove", self.watcher.watchlist_commands
         )
         cmd_link_data = self.watcher.get_command_link("cdndata")
 

--- a/cogs/nux.py
+++ b/cogs/nux.py
@@ -49,7 +49,7 @@ I'm {bot_display_name} and I'll be {guild.name}'s *personal* constellar :crystal
 
 :blue_heart: Thanks for trying out Algalon! :blue_heart:
 
-If you have any questions, concerns, or suggestions, please reach out to {owner_mention} here on Discord, or open a GitHub issue [here](https://github.com/Ghostopheles/better-algalon).
+If you have any questions, concerns, or suggestions, please reach out to {owner_mention} here on Discord, or open a GitHub issue [here](https://github.ghst.tools/better-algalon).
 """
         return nux_message
 

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -20,7 +20,7 @@ from .config import SUPPORTED_GAMES, SUPPORTED_PRODUCTS
 from .utils import get_discord_timestamp
 from .api.twitter import Twitter
 
-START_LOOPS = False
+START_LOOPS = True
 
 logger = logging.getLogger("discord.cdn.watcher")
 

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -98,15 +98,21 @@ class CDNCog(commands.Cog):
 
         logger.info("Cache configuration check complete")
 
-    def get_command_link(self, command: str):
-        all_cmds = self.get_commands()
+    def get_command_link(
+        self, command: str, cmd_group: Optional[discord.SlashCommandGroup] = None
+    ):
+        if cmd_group is not None and isinstance(cmd_group, discord.SlashCommandGroup):
+            all_cmds = cmd_group.subcommands
+        else:
+            all_cmds = self.get_commands()
+
         for cmd in all_cmds:
             if isinstance(cmd, bridge.BridgeCommand):
                 slash = cmd.slash_variant
                 if slash and slash.name == command:
                     return slash.mention
             elif isinstance(cmd, discord.SlashCommand):
-                if cmd.name == command and cmd.id is not None:
+                if cmd.qualified_name == command:
                     return cmd.mention
 
         return f"`/{command}`"

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -20,7 +20,7 @@ from .config import SUPPORTED_GAMES, SUPPORTED_PRODUCTS
 from .utils import get_discord_timestamp
 from .api.twitter import Twitter
 
-START_LOOPS = True
+START_LOOPS = False
 
 logger = logging.getLogger("discord.cdn.watcher")
 
@@ -41,6 +41,8 @@ ANNOUNCEMENT_CHANNELS = [
 
 DELETE_AFTER = 120
 COOLDOWN = 5
+
+ADMIN_ONLY_PERM = discord.Permissions(administrator=True)
 
 
 class CDNCog(commands.Cog):
@@ -506,10 +508,13 @@ class CDNCog(commands.Cog):
             message, ephemeral=True, delete_after=DELETE_AFTER
         )
 
-    @bridge.bridge_command(
-        name="addtowatchlist",
-        default_member_permissions=discord.Permissions(administrator=True),
-        guild_only=True,
+    watchlist_commands = discord.SlashCommandGroup(
+        name="watchlist", description="Watchlist commands", guild_only=True
+    )
+
+    @watchlist_commands.command(
+        name="add",
+        default_member_permissions=ADMIN_ONLY_PERM,
         input_type=str,
         min_length=3,
         max_length=500,
@@ -589,10 +594,9 @@ class CDNCog(commands.Cog):
                 delete_after=DELETE_AFTER,
             )
 
-    @bridge.bridge_command(
-        name="removefromwatchlist",
-        default_member_permissions=discord.Permissions(administrator=True),
-        guild_only=True,
+    @watchlist_commands.command(
+        name="remove",
+        default_member_permissions=ADMIN_ONLY_PERM,
         input_type=str,
         min_length=3,
         max_length=500,
@@ -623,10 +627,7 @@ class CDNCog(commands.Cog):
                 delete_after=DELETE_AFTER,
             )
 
-    @bridge.bridge_command(
-        name="watchlist",
-        guild_only=True,
-    )
+    @watchlist_commands.command(name="view")
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def cdn_watchlist(self, ctx: bridge.BridgeApplicationContext):
         """Returns the watchlist for your guild."""
@@ -646,10 +647,13 @@ class CDNCog(commands.Cog):
             message, ephemeral=True, delete_after=DELETE_AFTER
         )
 
-    @bridge.bridge_command(
-        name="setchannel",
-        default_member_permissions=discord.Permissions(administrator=True),
-        guild_only=True,
+    channel_commands = discord.SlashCommandGroup(
+        name="channel", description="Notification channel commands", guild_only=True
+    )
+
+    @channel_commands.command(
+        name="set",
+        default_member_permissions=ADMIN_ONLY_PERM,
     )
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def cdn_set_channel(
@@ -669,10 +673,7 @@ class CDNCog(commands.Cog):
             delete_after=DELETE_AFTER,
         )
 
-    @bridge.bridge_command(
-        name="getchannel",
-        guild_only=True,
-    )
+    @channel_commands.command(name="get")
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def cdn_get_channel(
         self,
@@ -707,9 +708,15 @@ class CDNCog(commands.Cog):
             delete_after=DELETE_AFTER,
         )
 
-    @bridge.bridge_command(
+    dm_commands = discord.SlashCommandGroup(
+        name="dm", description="DM notification commands"
+    )
+
+    @dm_commands.command(
         name="subscribe",
-        guild_ids=TEST_GUILDS,
+        input_type=str,
+        min_length=3,
+        max_length=500,
     )
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def user_subscribe(self, ctx: bridge.BridgeApplicationContext, branch: str):
@@ -744,9 +751,11 @@ class CDNCog(commands.Cog):
                     message, ephemeral=True, delete_after=DELETE_AFTER
                 )
 
-    @bridge.bridge_command(
+    @dm_commands.command(
         name="unsubscribe",
-        guild_ids=TEST_GUILDS,
+        input_type=str,
+        min_length=3,
+        max_length=500,
     )
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def user_unsubscribe(self, ctx: bridge.BridgeApplicationContext, branch: str):
@@ -783,10 +792,7 @@ class CDNCog(commands.Cog):
                     message, ephemeral=True, delete_after=DELETE_AFTER
                 )
 
-    @bridge.bridge_command(
-        name="subscribed",
-        guild_ids=TEST_GUILDS,
-    )
+    @dm_commands.command(name="view")
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def user_subscribed(self, ctx: bridge.BridgeApplicationContext):
         """View all branches you're receiving DM updates for."""


### PR DESCRIPTION
# DM Notifications
Adds the ability to subscribe to build notifications via DM instead of through the traditional server route. Subscribing to a branch will make Algalon send you a DM every time a build is pushed for that branch.

> [!TIP]
DM notifications use a minimized update format, intended to keep the content of the message readable on push notifications if you're on mobile.

You can interact with this system by using the `/dm` command group. Included commands are as follows:
- `/dm subscribe <branch>`
- `/dm unsubscribe <branch>`
- `/dm view`

As with the existing watchlist commands, both `subscribe` and `unsubscribe` support comma-delimited input.

# Command restructure
Currently, the commands are structured like a zoo and you end up with commands like `/addtowatchlist` - which is really just terrible.

I've moved most commands into command groups now to make them a bit better organized. For example, the aforementioned `/addtowatchlist` commands becomes `/watchlist add`, which I think is infinitely more premium.

Full list of migrated commands:
- `/addtowatchlist` -> `/watchlist add`
- `/removefromwatchlist` -> `/watchlist remove`
- `/watchlist` -> `/watchlist view`
- `/setchannel` -> `/channel set`
- `/getcchannel` -> `/channel get`