### PR TITLE
Support user installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ invite.txt
 cogs/cache/
 .vscode/
 *.code-workspace
+pycord/

--- a/bot.py
+++ b/bot.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         debug_guilds = [int(os.getenv("DEBUG_GUILD_ID")), int(os.getenv("DEBUG_GUILD_ID2"))]  # type: ignore
     else:  # is NOT debug mode
         token = os.getenv("DISCORD_TOKEN")
-        debug_guilds = []
+        debug_guilds = None
 
     bot = CDNBot(
         command_prefix="!",

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -83,15 +83,6 @@ Members (approx): {guild.approximate_member_count}\n
         await watcher.cdn_auto_refresh()
         await ctx.respond("Updates complete.", ephemeral=True, delete_after=300)
 
-    @commands.is_owner()
-    @admin_commands.command(name="nuxtest")
-    async def nuxtest(self, ctx: bridge.BridgeApplicationContext):
-        guild = ctx.guild
-        nux_cog = self.bot.get_cog("GuildNUX")
-        message = await nux_cog.get_nux_message(guild)
-
-        await ctx.respond(message, ephemeral=True, delete_after=300)
-
     # funni commands
 
     @bridge.bridge_command(

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -24,7 +24,6 @@ class AdminCog(commands.Cog):
         name="admin",
         description="Administration commands",
         guild_ids=HOME_GUILD,
-        contexts={discord.InteractionContextType.guild},
     )
 
     @commands.is_owner()

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -23,8 +23,8 @@ class AdminCog(commands.Cog):
     admin_commands = discord.SlashCommandGroup(
         name="admin",
         description="Administration commands",
-        guild_only=True,
         guild_ids=HOME_GUILD,
+        contexts={discord.InteractionContextType.guild},
     )
 
     @commands.is_owner()

--- a/cogs/nux.py
+++ b/cogs/nux.py
@@ -8,7 +8,7 @@ from .guild_config import GuildCFG
 logger = logging.getLogger("discord.nux")
 
 
-class GuildNUX(commands.Cog):
+class NUX(commands.Cog):
     def __init__(self, bot: bridge.Bot):
         self.bot = bot
         self.guild_cfg = GuildCFG()
@@ -69,4 +69,4 @@ If you have any questions, concerns, or suggestions, please reach out to {owner_
 
 
 def setup(bot):
-    bot.add_cog(GuildNUX(bot))
+    bot.add_cog(NUX(bot))

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -493,14 +493,26 @@ class CDNCog(commands.Cog):
 
     # DISCORD COMMANDS
 
-    @bridge.bridge_command(name="cdndata")
+    @bridge.bridge_command(
+        name="cdndata",
+        contexts={
+            discord.InteractionContextType.guild,
+            discord.InteractionContextType.bot_dm,
+        },
+    )
     async def cdn_data(self, ctx: bridge.BridgeApplicationContext):
         """Returns a paginator with the currently cached CDN data."""
         logger.debug("Generating paginator to display CDN data...")
         paginator = self.build_paginator_for_current_build_data()
         await paginator.respond(ctx.interaction, ephemeral=True)
 
-    @bridge.bridge_command(name="branches")
+    @bridge.bridge_command(
+        name="branches",
+        contexts={
+            discord.InteractionContextType.guild,
+            discord.InteractionContextType.bot_dm,
+        },
+    )
     @commands.cooldown(1, COOLDOWN, commands.BucketType.user)
     async def cdn_branches(self, ctx: bridge.BridgeApplicationContext):
         """Returns all observable branches."""
@@ -515,7 +527,9 @@ class CDNCog(commands.Cog):
         )
 
     watchlist_commands = discord.SlashCommandGroup(
-        name="watchlist", description="Watchlist commands", guild_only=True
+        name="watchlist",
+        description="Watchlist commands",
+        contexts={discord.InteractionContextType.guild},
     )
 
     @watchlist_commands.command(
@@ -654,7 +668,9 @@ class CDNCog(commands.Cog):
         )
 
     channel_commands = discord.SlashCommandGroup(
-        name="channel", description="Notification channel commands", guild_only=True
+        name="channel",
+        description="Notification channel commands",
+        contexts={discord.InteractionContextType.guild},
     )
 
     @channel_commands.command(
@@ -715,7 +731,13 @@ class CDNCog(commands.Cog):
         )
 
     dm_commands = discord.SlashCommandGroup(
-        name="dm", description="DM notification commands"
+        name="dm",
+        description="DM notification commands",
+        contexts={
+            discord.InteractionContextType.private_channel,
+            discord.InteractionContextType.bot_dm,
+        },
+        integration_types={discord.IntegrationType.user_install},
     )
 
     @dm_commands.command(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-cord==2.5.0
+py-cord[speed]==2.6.0
 httpx[http2]==0.27.0
 tweepy[async]==4.14.0
 pyyaml==6.0.1


### PR DESCRIPTION
Allows users to install Algalon to their Discord account instead of to a server. As of right now, this only allows you to customize your DM notifications via direct message to Algalon.