### PR TITLE
Hardcode branch encryption state

### DIFF
--- a/cogs/cdn_cache.py
+++ b/cogs/cdn_cache.py
@@ -82,15 +82,6 @@ class CDNCache:
                 )
                 return False
 
-            if not "encrypted" in file_json:  # just a safeguard
-                file_json["encrypted"] = None
-
-            if (
-                file_json["buildInfo"][branch]["encrypted"] == True
-                and newBuild["encrypted"] == None
-            ):
-                newBuild["encrypted"] = True
-
             # ignore builds with lower seqn numbers because it's probably just a caching issue
             new_seqn, old_seqn = int(newBuild["seqn"]), int(
                 file_json["buildInfo"][branch]["seqn"]

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -473,6 +473,7 @@ class LiveConfig(Singleton):
             cfg["products"][branch.name] = {
                 "public_name": branch.value,
                 "test_branch": branch in TEST_BRANCHES,
+                "encrypted": False,
             }
         return cfg
 
@@ -506,6 +507,12 @@ class LiveConfig(Singleton):
         data = LiveConfig.__open()
         if branch in data["products"].keys():
             return data["products"][branch]["public_name"]
+
+    @staticmethod
+    def get_product_encryption_state(branch: str):
+        data = LiveConfig.__open()
+        if branch in data["products"].keys():
+            return data["products"][branch]["encrypted"]
 
     @staticmethod
     def get_debug_value(key: str, default: Optional[Any] = None) -> Optional[str]:

--- a/cogs/ribbit_async.py
+++ b/cogs/ribbit_async.py
@@ -30,7 +30,6 @@ class Version:
     build: str
     build_text: str
     product_config: str
-    encrypted: bool
     branch: str
     seqn: int
 
@@ -57,7 +56,6 @@ class Version:
             "build": self.build,
             "build_text": self.build_text,
             "product_config": self.product_config,
-            "encrypted": self.encrypted,
             "branch": self.branch,
             "seqn": self.seqn,
         }
@@ -163,22 +161,6 @@ class RibbitClient:
             regionData = d
             regionData["region"] = region
             regionData["branch"] = product
-
-            if product != "catalogs":
-                try:
-                    encrypted = await TACT.is_encrypted(
-                        product, regionData["ProductConfig"]
-                    )
-                except:
-                    logger.error(
-                        f"Error occurred checking encryption status for {product}.",
-                        exc_info=True,
-                    )
-                    encrypted = None
-
-                regionData["encrypted"] = encrypted
-            else:
-                regionData["encrypted"] = False
 
             output[d["Region"]] = Version(regionData, sequence)
 

--- a/cogs/watcher.py
+++ b/cogs/watcher.py
@@ -191,7 +191,7 @@ class CDNCog(commands.Cog):
                 )
                 build = f"**{build}**" if build != build_old else build
 
-                encrypted = ":lock:" if ver["encrypted"] else ""
+                encrypted = ":lock:" if product_config[branch]["encrypted"] else ""
 
                 value_string += f"`{public_name} ({branch})`{encrypted}: {build_text_old}.{build_old} --> {build_text}.{build}\n"
 
@@ -244,27 +244,6 @@ class CDNCog(commands.Cog):
                         new_build_id = f"**{new_build_id}**"
 
                     message = f"{SUPPORTED_GAMES._value2member_map_[game].name} build: `{branch}` -> {new_build_text}.{new_build_id}"
-
-                    if (
-                        game == SUPPORTED_GAMES.Warcraft and update["encrypted"] != True
-                    ):  # determine if this build has been seen before on other public branches
-                        fresh_build = True
-                        for _branch in SUPPORTED_PRODUCTS:
-                            if _branch == branch:
-                                continue
-
-                            data = self.cdn_cache.load_build_data(_branch.name)
-                            if not data or data["encrypted"] == True:
-                                continue
-
-                            if int(new_build) > int(data["build"]):
-                                fresh_build = True
-                            else:
-                                fresh_build = False
-                                break
-
-                        if fresh_build:
-                            message = "New " + message
 
                     for subscriber in subscribers:
                         user = await self.bot.get_or_fetch_user(subscriber)

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     if dbg.debug_enabled:  # is debug mode
         token = os.getenv("DEBUG_DISCORD_TOKEN")
-        debug_guilds = [dbg.debug_guild_id]  # type: ignore
+        debug_guilds = None
     else:  # is NOT debug mode
         token = os.getenv("DISCORD_TOKEN")
         debug_guilds = None


### PR DESCRIPTION
For whatever godforsaken reason, some part of the HTTP request that is used to check product encryption state is not really asynchronous, so it slows the entire loop down while it waits for the response.

Encryption state doesn't really change, so I'm fine with hardcoding it for now until I can come up with a better solution.

This one simple trick brought the average version check time from 13 seconds to 200 milliseconds. Crazy, right?